### PR TITLE
refactor: Use `npx jest` as default `jest_cmd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ dependent on coc.nvim.
 
 - Neovim
 - NPM
-- Jest (will be ran with `npx` if not found locally)
 
 ## Installation
 
@@ -33,7 +32,8 @@ use 'mattkubej/jest.nvim'
 require'nvim-jest'.setup {
   -- Jest executable
   -- By default uses 'npx jest'
-  -- To override with an npm script, provide 'npm test --' or similar
+  -- To use an npm script, end the command with two dashes: 'npm test --'
+  -- You can also set the global `vim.g.jest_cmd` to override this configuration
   jest_cmd = '/relative/project/dir/node_modules/jest/bin/jest.js',
 
   -- Prevents tests from printing messages

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ dependent on coc.nvim.
 ## Requirements
 
 - Neovim
-- Jest (within node_modules of working project)
+- NPM
+- Jest (will be ran with `npx` if not found locally)
 
 ## Installation
 
@@ -31,7 +32,7 @@ use 'mattkubej/jest.nvim'
 ```lua
 require'nvim-jest'.setup {
   -- Jest executable
-  -- By default finds jest in the relative project directory
+  -- By default uses 'npx jest'
   -- To override with an npm script, provide 'npm test --' or similar
   jest_cmd = '/relative/project/dir/node_modules/jest/bin/jest.js',
 

--- a/lua/nvim-jest.lua
+++ b/lua/nvim-jest.lua
@@ -6,21 +6,12 @@ local function get_current_file_path()
   return vim.fn.expand("%:p")
 end
 
-local function get_current_folder_path()
-  return vim.fn.expand("%:p:h")
-end
-
 local function create_window()
   vim.cmd("botright vnew")
 end
 
 local function focus_last_accessed_window()
   vim.cmd("wincmd p")
-end
-
-local function get_local_jest()
-  local root_dir = vim.fn.finddir("node_modules/..", get_current_folder_path() .. ";")
-  return root_dir .. "/node_modules/jest/bin/jest.js"
 end
 
 local function run_jest(args)
@@ -44,7 +35,7 @@ function M.setup(user_data)
   end
 
   if config.jest_cmd == nil then
-    config.jest_cmd = get_local_jest()
+    config.jest_cmd = "npx jest"
   end
 
   if config.silent == nil then

--- a/lua/nvim-jest.lua
+++ b/lua/nvim-jest.lua
@@ -34,7 +34,9 @@ function M.setup(user_data)
     config.silent = user_data.silent or nil
   end
 
-  if config.jest_cmd == nil then
+  if vim.g.jest_cmd ~= nil then
+    config.jest_cmd = vim.g.jest_cmd
+  elseif config.jest_cmd == nil then
     config.jest_cmd = "npx jest"
   end
 


### PR DESCRIPTION
+ Slightly better start perf: No need to climb the directory tree
+ More flexible: Either runs the locally installed version or asks to install it temporarily*
+ Jest users (should) always have NPM installed, and as such, have `npx` available.

*A temporary install through `npx` still requires a config file present somewhere in the current working directory or above in the tree.
A default config file could fix that, but I think it should be the user's choice to set it up or not.
However, it would be nice to have an option to set the path to a global config file, and maybe recycle the old tree-climbing functions to find a local config, and then use the default if none is found... But then that wouldn't work with Jest configs from inside `package.json`. :confused: 